### PR TITLE
Fix: Correct wishlist payload structure in Details.js

### DIFF
--- a/movie_recommender/src/WebPages/Page6/Details.js
+++ b/movie_recommender/src/WebPages/Page6/Details.js
@@ -142,7 +142,7 @@ const Details = () => {
         const response = await fetch(SummaryApi.wishlistAdd.url, {
           method: SummaryApi.wishlistAdd.method,
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(movieData),
+          body: JSON.stringify({ movie: movieData }),
           credentials: 'include',
         });
         const data = await response.json();


### PR DESCRIPTION
I ensured that the movie data sent from the product details page to the backend for adding to the wishlist is correctly nested under a 'movie' key in the request body.

This aligns the payload with the backend controller's expectations, fixing the issue where adding to the wishlist from the details page was not working.